### PR TITLE
enable unauthenticated and authenticated routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,6 @@
 import Router from './Router'
 import Auth from './Auth'
 import Toast from './Toast'
-import User from './User'
 
 class App {
     constructor() {
@@ -17,11 +16,8 @@ class App {
         // toast init
         Toast.init()
 
-        // auth check
-        Auth.check(() => {
-            // authenticated
-            Router.init()
-        })
+        // authenticated
+        Router.init()
     }
 }
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,11 +1,13 @@
 // import views
 import homeView from './views/pages/home'
 import errorView from './views/pages/404'
+import authenticatedView from './views/pages/authenticated'
 
 // define routes
 const routes = {
     '/': homeView,
     '404': errorView,
+    '/authenticated': authenticatedView
 }
 
 class Router {

--- a/src/views/pages/authenticated.js
+++ b/src/views/pages/authenticated.js
@@ -1,0 +1,27 @@
+import App from '../../App'
+import {html, render } from 'lit-html'
+import Auth from '../../Auth'
+
+
+class AuthenticatedView {
+  init(){
+    console.log('AuthenticatedView.init')
+    document.title = 'Authenticated'    
+    // auth check
+    Auth.check(() => {
+      this.render()    
+    })
+  }
+
+  render(){
+    const template = html`
+      <div>        
+        <h1>Yay!</h1>
+        <p>Authenticated</p>
+      </div>      
+    `
+    render(template, App.rootEl)
+  }
+}
+
+export default new AuthenticatedView()


### PR DESCRIPTION
This PR shows the changes you will need to make to enable routing in your SPA.

It moves the authentication check from App to the init method of the page that requires authentication. This pattern can be replicated to add other pages.

Test by running app locally and visiting
localhost:1234/
localhost:1234/invalid
localhost:1234/authenticated (when an access token is present and when it is not)